### PR TITLE
Created SpecUtil to handle common api request config and common

### DIFF
--- a/src/test/java/com/api/tests/CountAPITest.java
+++ b/src/test/java/com/api/tests/CountAPITest.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import org.testng.annotations.Test;
 
 import com.api.utils.AuthTokenProvider;
+import com.api.utils.SpecUtil;
+
 import static com.api.utils.ConfigManager.*;
 
 import static io.restassured.module.jsv.JsonSchemaValidator.*;
@@ -18,17 +20,12 @@ public class CountAPITest {
 
 	@Test
 	public void verifyCountAPIResponse() throws IOException {
-		given().baseUri(getProperty("BASE_URI"))
-		.header("Authorization",AuthTokenProvider.getToken(FD))
-		.log().uri()
-		.log().method()
-		.log().headers()
+		given()
+	    .spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log()
-		.all()
-		.statusCode(200)
+		.spec(SpecUtil.responseSpec_OK())
 		.body("message", equalTo("Success"))
 		.time(lessThan(1000L))
 		.body("data", notNullValue())
@@ -41,16 +38,12 @@ public class CountAPITest {
 	
 	@Test
 	public void countAPITest_MissingAuthToken() throws IOException {
-		given().baseUri(getProperty("BASE_URI"))
-		.log().uri()
-		.log().method()
-		.log().headers()
+		given()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.get("dashboard/count")
 		.then()
-		.log()
-		.all()
-		.statusCode(401);
+		.spec(SpecUtil.responseSpec_TEXT(401));
 		
 	}
 

--- a/src/test/java/com/api/tests/LoginAPITest.java
+++ b/src/test/java/com/api/tests/LoginAPITest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 
 import com.api.pojo.UserCredentials;
 import com.api.utils.ConfigManager;
+import com.api.utils.SpecUtil;
 
 //import static com.api.utils.ConfigManager.*;
 
@@ -23,11 +24,11 @@ public class LoginAPITest {
 
 		
 		UserCredentials userCredentials = new UserCredentials("iamfd", "password");
-		given().baseUri(ConfigManager.getProperty("BASE_URI")).contentType(ContentType.JSON).accept(ContentType.JSON)
-				.body(userCredentials).log().uri().log().headers().log().method().log().body().when().post("/login")
+		given().spec(SpecUtil.requestSpec(userCredentials))
+				.when().post("/login")
 				.then()
-				.log().all()
-				.statusCode(200).time(lessThan(1000L)).body("message", equalTo("Success"))
+				.spec(SpecUtil.responseSpec_OK())
+				.body("message", equalTo("Success"))
 				.body(matchesJsonSchemaInClasspath("response-schema/LoginResponseSchema.json"));
 
 	}

--- a/src/test/java/com/api/tests/MasterAPITest.java
+++ b/src/test/java/com/api/tests/MasterAPITest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
 import com.github.fge.jsonschema.main.JsonValidator;
 
 import io.restassured.http.ContentType;
@@ -26,16 +27,12 @@ public class MasterAPITest {
 	public void masterAPITest() throws IOException {
 		
 		
-		given().baseUri(getProperty("BASE_URI"))
-		.header("Authorization",getToken(FD))
-		.contentType(ContentType.JSON)
-		.log().all()
+		given()
+		.spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
 		.post("master")   //default content type application/url-formencoded
 		.then()
-		.log().all()
-		.statusCode(200)
-		.time(lessThan(1000L))
+		.spec(SpecUtil.responseSpec_OK())
 		.body("message", equalTo("Success"))
 		.body("data", notNullValue())
 		.body("data", hasKey("mst_oem"))
@@ -54,15 +51,12 @@ public class MasterAPITest {
 	
 	@Test
 	public void invalidTokenMasterAPITest() throws IOException {
-		given().baseUri(getProperty("BASE_URI"))
-		.header("Authorization","")
-		.contentType(ContentType.JSON)
-		.log().all()
+		given()
+		.spec(SpecUtil.requestSpec())
 		.when()
 		.post("master")   //default content type application/url-formencoded
 		.then()
-		.log().all()
-		.statusCode(401);
+	.spec(SpecUtil.responseSpec_TEXT(401));
 		
 	}
 }

--- a/src/test/java/com/api/tests/UserDetailsAPITest.java
+++ b/src/test/java/com/api/tests/UserDetailsAPITest.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 
 import org.testng.annotations.Test;
 
+import com.api.utils.SpecUtil;
+
 import static com.api.constant.Role.*;
 
 import static com.api.utils.AuthTokenProvider.*;
@@ -23,14 +25,10 @@ public class UserDetailsAPITest {
 	public void userDetailsAPITest() throws IOException {
 		Header authHeader = new Header("Authorization",getToken(SUP));
 
-		given().baseUri(getProperty("BASE_URI")).header(authHeader).accept(ContentType.JSON)
-		.log().uri()
-		.log().method()
-		.log().headers()
-		.log().body()
+		given().spec(SpecUtil.requestSpecWithAuth(FD))
 		.when()
-				.get("userdetails").then().log().all()
-				.statusCode(200).time(lessThan(1000L))
+				.get("userdetails").then()
+				.spec(SpecUtil.responseSpec_OK())
 				.body(matchesJsonSchemaInClasspath("response-schema/UserDetailsResponseSchema.json"));
 	}
 

--- a/src/test/java/com/api/utils/SpecUtil.java
+++ b/src/test/java/com/api/utils/SpecUtil.java
@@ -1,0 +1,95 @@
+package com.api.utils;
+
+import java.io.IOException;
+
+import org.hamcrest.Matchers;
+
+import com.api.constant.Role;
+import com.api.pojo.UserCredentials;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+
+public class SpecUtil {
+	
+	public static RequestSpecification requestSpec() throws IOException {
+		RequestSpecification requestSpecification=new RequestSpecBuilder()
+				.setBaseUri(ConfigManager.getProperty("BASE_URI"))
+				.setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON)
+				.log(LogDetail.URI)
+				.log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS)
+				.log(LogDetail.BODY)
+				.build();
+		return requestSpecification;
+	}
+
+	
+	//post-put-patch(body)
+	public static RequestSpecification requestSpec(Object payload) throws IOException {
+		RequestSpecification requestSpecification=new RequestSpecBuilder()
+				.setBaseUri(ConfigManager.getProperty("BASE_URI"))
+				.setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON)
+				.setBody(payload)
+				.log(LogDetail.URI)
+				.log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS)
+				.log(LogDetail.BODY)
+				.build();
+		return requestSpecification;
+	}
+	
+	
+	public static RequestSpecification requestSpecWithAuth(Role role) throws IOException {
+		RequestSpecification requestSpecification=new RequestSpecBuilder()
+				.setBaseUri(ConfigManager.getProperty("BASE_URI"))
+				.setContentType(ContentType.JSON)
+				.setAccept(ContentType.JSON)
+				.addHeader("Authorization", AuthTokenProvider.getToken(role))
+				.log(LogDetail.URI)
+				.log(LogDetail.METHOD)
+				.log(LogDetail.HEADERS)
+				.log(LogDetail.BODY)
+				.build();
+		return requestSpecification;
+	}
+	
+
+		public static ResponseSpecification responseSpec_OK() throws IOException {
+			ResponseSpecification responseSpecification=new ResponseSpecBuilder()
+					
+					.expectContentType(ContentType.JSON)
+					.expectStatusCode(200)
+					.expectResponseTime(Matchers.lessThan(1000L))
+					.log(LogDetail.ALL)
+					.build();
+			return responseSpecification;
+		}
+		
+		public static ResponseSpecification responseSpec_JSON(int statusCode) throws IOException {
+			ResponseSpecification responseSpecification=new ResponseSpecBuilder()
+					
+					.expectContentType(ContentType.JSON)
+					.expectStatusCode(statusCode)
+					.expectResponseTime(Matchers.lessThan(1000L))
+					.log(LogDetail.ALL)
+					.build();
+			return responseSpecification;
+		}
+		
+		public static ResponseSpecification responseSpec_TEXT(int statusCode) throws IOException {
+			ResponseSpecification responseSpecification=new ResponseSpecBuilder()
+					.expectStatusCode(statusCode)
+					.expectResponseTime(Matchers.lessThan(1000L))
+					.log(LogDetail.ALL)
+					.build();
+			return responseSpecification;
+		}
+	
+}


### PR DESCRIPTION
SpecUtil is consisting of common RequestSpecBuilder and ResponseSpecBuilder. These util methods has reduced the boilerplate code in our api tests and also reduced the the bumber of lines.Making test code smaller and maintainable